### PR TITLE
some log is too more verbose in normal run

### DIFF
--- a/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
@@ -1924,7 +1924,7 @@ public abstract class AbstractInvokerMojo
 
         if ( executionResult != null && executionResult.fileLogger != null )
         {
-            getLog().info( "fileLogger:" + executionResult.fileLogger.getOutputFile() );
+            getLog().debug( "fileLogger:" + executionResult.fileLogger.getOutputFile() );
             try
             {
                 systemOut.setValue( FileUtils.fileRead( executionResult.fileLogger.getOutputFile() ) );
@@ -1937,7 +1937,7 @@ public abstract class AbstractInvokerMojo
         }
         else
         {
-            getLog().info( safeFileName + ", executionResult:" + executionResult );
+            getLog().debug( safeFileName + ", executionResult:" + executionResult );
         }
         try ( FileOutputStream fos = new FileOutputStream( reportFile );
               Writer osw = new OutputStreamWriter( fos, buildJob.getModelEncoding() ) )


### PR DESCRIPTION
this information doesn't have any context in build output