### PR TITLE
[MINVOKER-254] Bump groovy to the latest in 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@ under the License.
         <jdk>[1.7,)</jdk>
       </activation>
       <properties>
-        <groovy-version>2.4.18</groovy-version>
+        <groovy-version>2.4.19</groovy-version>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
As [3.2.2](https://issues.apache.org/jira/projects/MINVOKER/versions/12346157) is still unreleased, I think this change can be covered by [MINVOKER-254](https://issues.apache.org/jira/browse/MINVOKER-254).

[Changes in Groovy 2.4.19](http://groovy-lang.org/changelogs/changelog-2.4.19.html)