### PR TITLE
Bump commons-io to 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@ under the License.
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.5</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
There is a conflict with maven-shared-utils 3.2.1 which still uses 2.5
I have requested a new release with that version (https://issues.apache.org/jira/browse/MSHARED-847)