### PR TITLE
[MINVOKER-254] Bump groovy to the latest in 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@ under the License.
     <beanshell-version>2.0b5</beanshell-version>
     <groovy-groupId>org.codehaus.groovy</groovy-groupId>
     <groovy-artifactId>groovy-all</groovy-artifactId>
-    <groovy-version>2.4.19</groovy-version>
+    <groovy-version>2.4.20</groovy-version>
     <surefire.version>2.22.2</surefire.version>
     <project.build.outputTimestamp>2020-02-22T16:40:59Z</project.build.outputTimestamp>
   </properties>


### PR DESCRIPTION
As [3.2.2](https://issues.apache.org/jira/projects/MINVOKER/versions/12346157) is still unreleased, I think this change can be covered by [MINVOKER-254](https://issues.apache.org/jira/browse/MINVOKER-254).

[Changes in Groovy 2.4.20](http://groovy-lang.org/changelogs/changelog-2.4.20.html)

As follow-up to #15.