### PR TITLE
[MINVOKER-273] Environment variable with empty value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@ under the License.
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-invoker-plugin</artifactId>
-              <version>3.2.1</version>
+              <version>3.2.2</version>
               <configuration>
                 <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                 <preBuildHookScript>setup</preBuildHookScript>

--- a/src/it/invocation-environmentvariable/invoker.properties
+++ b/src/it/invocation-environmentvariable/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.environmentVariables.MINVOKER273_PROPERTIES1 = minvoker273_properties1
+invoker.environmentVariables.MINVOKER273_PROPERTIES2 = minvoker273_properties2

--- a/src/it/invocation-environmentvariable/src/it/minvoker-273/pom.xml
+++ b/src/it/invocation-environmentvariable/src/it/minvoker-273/pom.xml
@@ -22,13 +22,10 @@ under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <groupId>org.apache.maven.plugins.invoker.its</groupId>
-  <artifactId>invocation-environmentvariable</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <artifactId>minvoker-273</artifactId>
+  <version>0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
-
-  <description>Test if the environmentvariable is applied</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -38,32 +35,17 @@ under the License.
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-invoker-plugin</artifactId>
-        <version>@project.version@</version>
-        <configuration>
-          <debug>true</debug>
-          <postBuildHookScript>verify</postBuildHookScript>
-          <goals>
-            <goal>validate</goal>
-          </goals>
-          <environmentVariables>
-            <MINVOKER145>foobar</MINVOKER145>
-            <MINVOKER255_POM>minvoker255_pom</MINVOKER255_POM>
-            <MINVOKER273_PROPERTIES1/>
-            <MINVOKER273_PROPERTIES3/>
-          </environmentVariables>
-        </configuration>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <execution>
-            <id>integration-test</id>
-            <phase>initialize</phase>
+            <phase>validate</phase>
             <goals>
-              <goal>run</goal>
+              <goal>system</goal>
             </goals>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/src/it/invocation-environmentvariable/verify.groovy
+++ b/src/it/invocation-environmentvariable/verify.groovy
@@ -16,6 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-def buildLog = new File( basedir, 'build.log' )
-assert buildLog.text.contains('[INFO] BUILD SUCCESS')
+
+def buildLog = new File( basedir, 'build.log' ).text
+assert buildLog.contains('[INFO] BUILD SUCCESS')
+
+def buildLod273 = new File( basedir, 'src/it/minvoker-273/build.log' ).text
+
+// MINVOKER273_PROPERTIES1 is present in system environment and should be removed
+assert !buildLod273.contains('MINVOKER273_PROPERTIES1')
+
+// MINVOKER273_PROPERTIES2 is present in system environment and should be present in invocation
+assert buildLod273.contains('MINVOKER273_PROPERTIES2=minvoker273_properties2')
+
+// MINVOKER273_PROPERTIES3 is not present in system environment and should not be present in invocation
+assert !buildLod273.contains('MINVOKER273_PROPERTIES3')
 


### PR DESCRIPTION
After fix in `maven-shared-utils` we only need some tests for confirmation.