### PR TITLE
Bump mockito-core and commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@ under the License.
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -259,7 +259,7 @@ under the License.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>4.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/maven/plugins/invoker/InvokerPropertiesTest.java
+++ b/src/test/java/org/apache/maven/plugins/invoker/InvokerPropertiesTest.java
@@ -40,8 +40,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -115,7 +115,7 @@ public class InvokerPropertiesTest
         InvokerProperties facade = new InvokerProperties( null );
 
         facade.configureInvocation( request, 0 );
-        verifyZeroInteractions( request );
+        verifyNoInteractions( request );
     }
 
     @Test
@@ -250,7 +250,7 @@ public class InvokerPropertiesTest
         {
             assertEquals( "The string 'xxxUnKnown' can not be converted to enumeration.", e.getMessage() );
         }
-        verifyZeroInteractions( request );
+        verifyNoInteractions( request );
     }
 
 


### PR DESCRIPTION
Since java 8 is available in project we can track the newest versions