### PR TITLE
Correct doc: Replace `activeByDefault` by `activeProfiles`.

### DIFF
--- a/src/site/apt/examples/fast-use.apt.vm
+++ b/src/site/apt/examples/fast-use.apt.vm
@@ -70,9 +70,6 @@ Fast Build Configuration
   <profiles>
     <profile>
       <id>it-repo</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <repositories>
         <repository>
           <id>local.central</id>
@@ -99,6 +96,9 @@ Fast Build Configuration
       </pluginRepositories>
     </profile>
   </profiles>
+  <activeProfiles>
+    <activeProfile>it-repo</activeProfile>
+  </activeProfiles>
 </settings>
 +------------------
 


### PR DESCRIPTION
`activeByDefault` does not work with extensions from `.mvn/extensions.xml`. It might also be more fragile, if other profiles are used, since it only has effect, if no other profiles are activated.