### PR TITLE
Fix Modello namespace

### DIFF
--- a/src/main/mdo/invocation.mdo
+++ b/src/main/mdo/invocation.mdo
@@ -19,8 +19,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<model xmlns="https://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://codehaus-plexus.github.io/MODELLO/1.4.0 https://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd"
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.4.0 https://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd"
        xsd.namespace="http://maven.apache.org/plugins/maven-invoker-plugin/build-job/1.0.0"
        xsd.targetNamespace="http://maven.apache.org/plugins/maven-invoker-plugin/build-job/1.0.0">
   <id>build-job</id>


### PR DESCRIPTION
Similar:
- https://github.com/apache/maven-release/pull/102

Seems this upgrade to https was done on 2018-03-13 in several repositories, but no worries - I'm not going to track them all, that's the last one I do.