### PR TITLE
[MINVOKER-289] - Support for shared invoker's Update-Snapshots Flag

### DIFF
--- a/src/it/MINVOKER-289/pom.xml
+++ b/src/it/MINVOKER-289/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.invoker</groupId>
+  <artifactId>update-snapshots</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <description>Test to check that update snapshots gets set in the shared maven invoker</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+          <writeJunitReport>true</writeJunitReport>
+          <debug>true</debug>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+          <pomIncludes>
+            <pomInclude>*/pom.xml</pomInclude>
+          </pomIncludes>
+          <goals>
+            <goal>validate</goal>
+          </goals>
+          <updateSnapshots>true</updateSnapshots>
+        </configuration>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/MINVOKER-289/src/it/project/pom.xml
+++ b/src/it/MINVOKER-289/src/it/project/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test</groupId>
+  <artifactId>update-snapshot</artifactId>
+  <version>0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/src/it/MINVOKER-289/src/it/project/prebuild.bsh
+++ b/src/it/MINVOKER-289/src/it/project/prebuild.bsh
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+
+// marker for parent build that this sub build was indeed run
+File touchFile = new File( basedir, "touch.txt" );
+touchFile.createNewFile();

--- a/src/it/MINVOKER-289/verify.groovy
+++ b/src/it/MINVOKER-289/verify.groovy
@@ -1,0 +1,36 @@
+import java.lang.reflect.Array
+import java.util.stream.Collectors
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File( basedir, 'target/it/project/touch.txt' )
+
+File buildLog = new File( basedir, 'build.log' )
+
+String executionString = "Executing:"
+int mavenCommandIndex = buildLog.text.indexOf( executionString )
+String commandLine = buildLog.text.substring( mavenCommandIndex, buildLog.text.indexOf( System.lineSeparator(),
+        mavenCommandIndex ) )
+commandLine = commandLine.substring(commandLine.indexOf("mvn"));
+
+assert Arrays.stream( commandLine.split( '\\s' ) )
+    .map( f -> f.replaceAll('\'', ''))
+    .filter(f -> f == '-U')
+    .count() > 0

--- a/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
@@ -595,6 +595,11 @@ public abstract class AbstractInvokerMojo
      * invoker.environmentVariables.&lt;variableName&gt; = variableValue
      * invoker.environmentVariables.MY_ENV_NAME = myEnvValue
      *
+     * # A boolean value indicating a check for missing releases and updated snapshots on remote repositories to be done
+     * # Passed to the invoker. Same as passing -U, --update-snapshots flag on the command line
+     * # Since plugin version 3.4.0
+     * invoker.updateSnapshots = true
+     *
      * </pre>
      *
      * @since 1.2
@@ -676,6 +681,15 @@ public abstract class AbstractInvokerMojo
      */
     @Parameter( defaultValue = "false", property = "invoker.updateOnly" )
     private boolean updateOnly = false;
+
+    /**
+     * Force a check for missing releases and updated snapshots on remote repositories. This is passed to the invoked
+     * maven projects (it is the same as if you were to use the -U, --update-snapshots flag on the command line).
+     *
+     * @since 3.4.0
+     */
+    @Parameter( defaultValue = "false", property = "invoker.updateSnapshots" )
+    private boolean updateSnapshots;
 
     // internal state variables
 
@@ -2684,6 +2698,7 @@ public abstract class AbstractInvokerMojo
         invokerProperties.setDefaultMavenOpts( mavenOpts );
         invokerProperties.setDefaultTimeoutInSeconds( timeoutInSeconds );
         invokerProperties.setDefaultEnvironmentVariables( environmentVariables );
+        invokerProperties.setDefaultUpdateSnapshots( updateSnapshots );
 
 
         return invokerProperties;

--- a/src/main/java/org/apache/maven/plugins/invoker/InvokerProperties.java
+++ b/src/main/java/org/apache/maven/plugins/invoker/InvokerProperties.java
@@ -56,6 +56,7 @@ class InvokerProperties
     private Integer defaultTimeoutInSeconds;
     private Map<String, String> defaultEnvironmentVariables;
     private File defaultMavenExecutable;
+    private Boolean defaultUpdateSnapshots;
 
     private enum InvocationProperty
     {
@@ -72,7 +73,8 @@ class InvokerProperties
         DEBUG( "invoker.debug" ),
         QUIET( "invoker.quiet" ),
         SETTINGS_FILE( "invoker.settingsFile" ),
-        TIMEOUT_IN_SECONDS( "invoker.timeoutInSeconds" );
+        TIMEOUT_IN_SECONDS( "invoker.timeoutInSeconds" ),
+        UPDATE_SNAPSHOTS( "invoker.updateSnapshots" );
 
         private final String key;
 
@@ -194,6 +196,15 @@ class InvokerProperties
     public void setDefaultEnvironmentVariables( Map<String, String> defaultEnvironmentVariables )
     {
         this.defaultEnvironmentVariables = defaultEnvironmentVariables;
+    }
+
+    /**
+     * Default value for updateSnapshots
+     * @param defaultUpdateSnapshots a default value
+     */
+    public void setDefaultUpdateSnapshots( boolean defaultUpdateSnapshots )
+    {
+        this.defaultUpdateSnapshots = defaultUpdateSnapshots;
     }
 
     /**
@@ -475,6 +486,10 @@ class InvokerProperties
         setIfNotNull( request::setTimeoutInSeconds, get( InvocationProperty.TIMEOUT_IN_SECONDS, index )
             .map( Integer::parseInt )
             .orElse( defaultTimeoutInSeconds ) );
+
+        setIfNotNull( request::setUpdateSnapshots, get( InvocationProperty.UPDATE_SNAPSHOTS, index )
+                .map( Boolean::parseBoolean )
+                .orElse( defaultUpdateSnapshots ) );
 
         Optional.ofNullable( defaultEnvironmentVariables )
                 .ifPresent( evn -> evn.forEach( request::addShellEnvironment ) );

--- a/src/test/java/org/apache/maven/plugins/invoker/InvokerPropertiesTest.java
+++ b/src/test/java/org/apache/maven/plugins/invoker/InvokerPropertiesTest.java
@@ -455,6 +455,43 @@ public class InvokerPropertiesTest
     }
 
     @Test
+    public void testConfigureUpdateSnapshots()
+    {
+        Properties props = new Properties();
+        InvokerProperties facade = new InvokerProperties( props );
+
+        props.setProperty( "invoker.updateSnapshots", "true" );
+        facade.configureInvocation( request, 1 );
+        verify( request ).setUpdateSnapshots( true );
+        clearInvocations( request );
+        props.clear();
+
+        props.setProperty( "invoker.updateSnapshots", "false" );
+        facade.configureInvocation( request , 1 );
+        verify( request ).setUpdateSnapshots( false );
+
+        verifyNoMoreInteractions( request );
+    }
+
+    @Test
+    public void testConfigureUpdateSnapshotsDefault()
+    {
+        Properties props = new Properties();
+        InvokerProperties facade = new InvokerProperties( props );
+
+        facade.setDefaultUpdateSnapshots( true );
+        facade.configureInvocation( request, 1 );
+        verify( request ).setUpdateSnapshots( true );
+        clearInvocations( request );
+
+        facade.setDefaultUpdateSnapshots( false );
+        facade.configureInvocation( request, 1 );
+        verify( request ).setUpdateSnapshots( false );
+
+        verifyNoMoreInteractions( request );
+    }
+
+    @Test
     public void testIsInvocationDefined()
     {
         Properties props = new Properties();
@@ -541,5 +578,4 @@ public class InvokerPropertiesTest
         assertThat( toolchain.getType() ).isEqualTo( "jdk" );
         assertThat( toolchain.getProvides() ).containsExactlyEntriesOf( Collections.singletonMap( "version", "11" ) );
     }
-
 }


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MINVOKER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MINVOKER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MINVOKER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

A new parameter **updateSnapshots** has been added to AbstractInvokerMojo which is passed into the shared invoker's InvocationRequest object before being passed into invoker.execute. It can also read the property from invoker.properties file property invoker.updateSnapshots
