### PR TITLE
[MINVOKER-318] - invoker:install must resolve deps in 'test' scope

### DIFF
--- a/src/it/fail-test-scope/invoker.properties
+++ b/src/it/fail-test-scope/invoker.properties
@@ -1,0 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=clean invoker:install
+invoker.buildResult = success
+invoker.failureBehavior = fail-at-end

--- a/src/it/fail-test-scope/pom.xml
+++ b/src/it/fail-test-scope/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.invoker</groupId>
+  <artifactId>fail-build</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <description>Ensure that overlapping runtime and test dependencies are both installed in the local repository</description>
+
+  <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <dep.commons-lang.version>3.12.0</dep.commons-lang.version>
+  </properties>
+
+  <dependencies>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <version>${dep.commons-lang.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <version>${dep.commons-lang.version}</version>
+          <scope>test</scope>
+          <classifier>tests</classifier>
+      </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+            <settingsFile>src/it/settings.xml</settingsFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/fail-test-scope/src/it/settings.xml
+++ b/src/it/fail-test-scope/src/it/settings.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <!--
+      NOTE: We don't use @localRepository@ here which refers to the isolated local repository of the ITs and is quite
+      empty. In contrast, @invoker.repo.local@ has been defined to refer to the original local repository which is a
+      far better source for artifacts.
+      -->
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>file://@invoker.repo.local@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>file://@invoker.repo.local@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/src/it/fail-test-scope/verify.bsh
+++ b/src/it/fail-test-scope/verify.bsh
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.regex.*;
+
+try
+{
+    // see if both the commons-lang jar and the commons-lang-tests jar were installed
+
+    File jarFile = new File( basedir, "target/local-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar" );
+    System.out.println( "Checking for jar file: " + jarFile );
+    if ( !jarFile.exists() )
+    {
+        System.out.println( "FAILED! No jar file found!" );
+        return false;
+    }
+
+    File jarTestsFile = new File( basedir, "target/local-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0-tests.jar" );
+    System.out.println( "Checking for test jar file: " + jarTestsFile );
+    if ( !jarTestsFile.exists() )
+    {
+        System.out.println( "FAILED! No test jar file found!" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/invoker/InstallMojo.java
+++ b/src/main/java/org/apache/maven/plugins/invoker/InstallMojo.java
@@ -83,7 +83,7 @@ import org.codehaus.plexus.util.FileUtils;
 @Mojo(
         name = "install",
         defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST,
-        requiresDependencyResolution = ResolutionScope.RUNTIME,
+        requiresDependencyResolution = ResolutionScope.TEST,
         threadSafe = true)
 // CHECKSTYLE_ON: LineLength
 public class InstallMojo extends AbstractMojo {


### PR DESCRIPTION
When integration tests require dependencies in "test" scope, that overlap with dependencies in "runtime" scope (e.g. the normal jar in runtime scope and a "tests" jar in test scope), the install goal will not resolve and install the test dependency because it requests only runtime scope resolution.

This PR contains an integration tests to demonstrate the problem. The change is trivial: make the "install" goal resolve its dependencies in test, not in runtime scope.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MINVOKER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MINVOKER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MINVOKER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

