### PR TITLE
[MINVOKER-374] Ability to skip project collection

### DIFF
--- a/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
@@ -217,9 +217,6 @@ public abstract class AbstractInvokerMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private boolean cloneClean;
 
-    @Parameter
-    private List<String> collectedProjects;
-
     /**
      * A single POM to build, skipping any scanning parameters and behavior.
      *
@@ -697,6 +694,18 @@ public abstract class AbstractInvokerMojo extends AbstractMojo {
      */
     @Parameter(defaultValue = "false", property = "invoker.updateSnapshots")
     private boolean updateSnapshots;
+
+    /**
+     * Projects that are cloned undergo some filtering. In order to grab all projects and make sure
+     * they are all filtered, projects are read and parsed. In some cases, this may not be a desired
+     * behavior (especially when some pom.xml cannot be parsed by Maven directly).  In such cases,
+     * the exact list of projects can be set using this field, avoiding the parsing of all pom.xml
+     * files found.
+     *
+     * @since 3.9.0
+     */
+    @Parameter
+    private List<String> collectedProjects;
 
     // internal state variables
 

--- a/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
@@ -217,6 +217,9 @@ public abstract class AbstractInvokerMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private boolean cloneClean;
 
+    @Parameter
+    private List<String> collectedProjects;
+
     /**
      * A single POM to build, skipping any scanning parameters and behavior.
      *
@@ -802,11 +805,6 @@ public abstract class AbstractInvokerMojo extends AbstractMojo {
 
         handleScriptRunnerWithScriptClassPath();
 
-        Collection<String> collectedProjects = new LinkedHashSet<>();
-        for (BuildJob buildJob : buildJobs) {
-            collectProjects(projectsDirectory, buildJob.getProject(), collectedProjects, true);
-        }
-
         File projectsDir = projectsDirectory;
 
         if (cloneProjectsTo == null && "maven-plugin".equals(project.getPackaging())) {
@@ -826,6 +824,13 @@ public abstract class AbstractInvokerMojo extends AbstractMojo {
         }
 
         if (cloneProjectsTo != null) {
+            Collection<String> collectedProjects = this.collectedProjects;
+            if (collectedProjects == null) {
+                collectedProjects = new LinkedHashSet<>();
+                for (BuildJob buildJob : buildJobs) {
+                    collectProjects(projectsDirectory, buildJob.getProject(), collectedProjects, true);
+                }
+            }
             cloneProjects(collectedProjects);
             addMissingDotMvnDirectory(cloneProjectsTo, buildJobs);
             projectsDir = cloneProjectsTo;
@@ -1088,7 +1093,7 @@ public abstract class AbstractInvokerMojo extends AbstractMojo {
      *
      * @param projectPaths The paths to the projects to clone, relative to the projects directory, must not be
      *            <code>null</code> nor contain <code>null</code> elements.
-     * @throws org.apache.maven.plugin.MojoExecutionException If the the projects could not be copied/filtered.
+     * @throws org.apache.maven.plugin.MojoExecutionException If the projects could not be copied/filtered.
      */
     private void cloneProjects(Collection<String> projectPaths) throws MojoExecutionException {
         if (!cloneProjectsTo.mkdirs() && cloneClean) {


### PR DESCRIPTION
JIRA issue: [MINVOKER-374](https://issues.apache.org/jira/browse/MINVOKER-374)

This is required for [Maven XInclude extension](https://github.com/apache/maven-xinclude-extension) which has pom files which cannot be parsed by stock maven (that's the whole point of the extension).
The invoker plugin loads the POMs to find which files need to be filtered and thus cause the plugin execution to fail.