### PR TITLE
Add note about cloneProjectsTo being required for filtering

### DIFF
--- a/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
+++ b/src/main/java/org/apache/maven/plugins/invoker/AbstractInvokerMojo.java
@@ -188,6 +188,7 @@ public abstract class AbstractInvokerMojo extends AbstractMojo {
      * (<b>Exception</b> when project using invoker plugin is of <i>maven-plugin</i> packaging:
      * In such case IT projects will be cloned to and executed in <code>target/its</code> by default.)
      *
+     * Note: cloning needs to be enabled for properties filtering to work.
      * @since 1.1
      */
     @Parameter(property = "invoker.cloneProjectsTo")

--- a/src/site/apt/examples/filtering.apt.vm
+++ b/src/site/apt/examples/filtering.apt.vm
@@ -41,6 +41,8 @@ Filtering Files
   * The invoker properties, the goals file and the profiles file. Tokens in these files must use the usual Maven syntax
     <<<$\{...\}>>>.
 
+  Note: for filtering to work, the <<<cloneProjectsTo>>> property of the <<<invoker:run>>> goal must be set.
+
   []
 
   The following example directory structure highlights the files which are filtered by the Invoker Plugin:


### PR DESCRIPTION
 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MINVOKER) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MINVOKER-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MINVOKER-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

It took me a while to figure out why filtering didn't work. This happened on a maven-enforcer rule project, 
so the `cloneProjectsTo` property was not set automatically (in contrast to maven-plugin projects).