### PR TITLE
Do not assume how often Maven reports a model problem

### DIFF
--- a/src/it/fail-build-streamLogsOnFailures/verify.groovy
+++ b/src/it/fail-build-streamLogsOnFailures/verify.groovy
@@ -30,7 +30,12 @@ assert buildLog.contains('*** build.log for execution: 2 ***')
 assert buildLog.contains(buildLogOfProject)
 assert buildLog.contains('*** end build.log for: project' + FS + 'pom.xml ***')
 
-// the build was re-run so the error is logged twice, once for each run
-assert buildLog.count("[FATAL] 'modelVersion' of '99.0.0'") == 2
+// the build was re-run, so the streamed output holds each run's log exactly once.
+// How often Maven itself reports a model problem per run is a Maven detail that
+// varies between versions, so compare against the forked logs instead of a
+// hard-coded count.
+def marker = "[FATAL] 'modelVersion' of '99.0.0'"
+assert buildLogOfProject1.count(marker) > 0
+assert buildLog.count(marker) == buildLogOfProject1.count(marker) + buildLogOfProject.count(marker)
 
 assert buildLog.contains('ERROR] Failed to execute goal org.apache.maven.plugins:maven-invoker-plugin:' + projectVersion + ':run')


### PR DESCRIPTION
`fail-build-streamLogsOnFailures` asserts that the streamed log contains

```groovy
assert buildLog.count("[FATAL] 'modelVersion' of '99.0.0'") == 2
```

one occurrence per invoker rerun. That counts how many times *Maven core* prints
a single model problem, which is not something this IT should be pinning down.

Since 4.0.0-rc-6 core reports every model problem twice — once in a new grouped
per-file block, and again in the `ProjectBuildingException` summary it has always
emitted — so the count is 4 and the IT fails. It reproduces with no plugin
involved, on a pom whose only content is `<modelVersion>99.0.0</modelVersion>`:
rc-5 prints the line once, rc-6 twice. I have reported that separately as a core
regression; this change is worth making regardless of how core resolves it.

The streamed outer log embeds each forked run's log verbatim, so the assertion
can be expressed against those logs instead of a hard-coded number:

```groovy
def marker = "[FATAL] 'modelVersion' of '99.0.0'"
assert buildLogOfProject1.count(marker) > 0
assert buildLog.count(marker) == buildLogOfProject1.count(marker) + buildLogOfProject.count(marker)
```

That still asserts what the IT is about — both runs were streamed, each exactly
once, neither dropped nor duplicated — and holds whatever core chooses to print.
The first line keeps the check honest if the marker ever stops appearing at all,
which would otherwise make the equality trivially true at `0 == 0 + 0`.

This is the only IT in the repository that counts occurrences of a Maven-emitted
diagnostic; the other `count()` assertions are all over the invoker plugin's own
output, which is ours to control.

Verified locally on 3.9.16, 4.0.0-rc-5 and 4.0.0-rc-6 (counts 2 = 1+1, 2 = 1+1
and 4 = 2+2 respectively), and green on the full matrix on my fork including all
six 4.0.0-rc-6 cells:
https://github.com/slachiewicz/maven-invoker-plugin/actions/runs/31166911077
