### PR TITLE
Drop the version.plexus-utils property the parent already provides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,6 @@ under the License.
     <beanshell-version>2.0b6</beanshell-version>
     <project.build.outputTimestamp>2026-05-02T20:49:38Z</project.build.outputTimestamp>
     <groovyVersion>4.0.33</groovyVersion>
-    <!-- TODO check with next parent -->
-    <version.plexus-utils>4.0.3</version.plexus-utils>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
`org.apache.maven:maven-parent:49` already sets `version.plexus-utils` to **4.0.3** — the identical value — so the local property restates what is inherited and simply has to be kept in step with the parent by hand.

Part of a sweep across the Maven repositories for local pom properties that no longer override anything. `mvn help:effective-pom` still resolves plexus-utils to 4.0.3 with the line gone.

Generated-by: Claude Opus 5 (1M context)
