### PR TITLE
Document how to use a JVM debugger with invoker ITs #708

### DIFF
--- a/src/site/markdown/examples/debugging.md.vm
+++ b/src/site/markdown/examples/debugging.md.vm
@@ -23,31 +23,10 @@ Sometimes you need to debug an integration test exactly as the Invoker Plugin ra
 
 # Using mvnDebug
 
-Each IT runs in a forked Maven process. The easiest way to attach a JVM debugger to that process is to set the [`mavenExecutable`](../run-mojo.html#mavenExecutable) parameter to `mvnDebug`. Maven ships this script next to `mvn`; it listens for a remote debugger on port 8000 and waits until one attaches.
+Each IT runs in a forked Maven process. To attach a JVM debugger to one IT, set the [`mavenExecutable`](../run-mojo.html#mavenExecutable) parameter to `mvnDebug` and select that project with [`invoker.test`](../run-mojo.html#invokerTest). Maven ships this script next to `mvn`; it listens for a remote debugger on port 8000 and waits until one attaches.
 
 ```shell
-mvn verify -Dinvoker.mavenExecutable=mvnDebug
-```
-
-Or in the plugin configuration:
-
-```xml
-<project>
-  ...
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-invoker-plugin</artifactId>
-        <version>${project.version}</version>
-        <configuration>
-          <mavenExecutable>mvnDebug</mavenExecutable>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-  ...
-</project>
+mvn verify -Dinvoker.mavenExecutable=mvnDebug -Dinvoker.test=my-it
 ```
 
 You can also set it for a single project in `invoker.properties`:
@@ -58,18 +37,12 @@ invoker.mavenExecutable = mvnDebug
 
 Then attach a remote debugger (for example Eclipse "Remote Java Application" via Run &gt; Open Debug Dialog...) to `localhost:8000`.
 
-To debug only one IT, combine this with [`invoker.test`](../run-mojo.html#invokerTest):
-
-```shell
-mvn verify -Dinvoker.mavenExecutable=mvnDebug -Dinvoker.test=my-it
-```
-
 # Using mavenOpts
 
 If you need a different listen address or port, leave the default Maven executable and pass a JDWP agent through [`mavenOpts`](../run-mojo.html#mavenOpts) (`MAVEN_OPTS` of the forked Maven):
 
 ```shell
-mvn verify -Dinvoker.mavenOpts="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005"
+mvn verify -Dinvoker.test=my-it -Dinvoker.mavenOpts="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005"
 ```
 
 # The debug parameter

--- a/src/site/markdown/examples/debugging.md.vm
+++ b/src/site/markdown/examples/debugging.md.vm
@@ -1,0 +1,77 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Debugging Tests
+
+Sometimes you need to debug an integration test exactly as the Invoker Plugin ran it. Here's how.
+
+# Using mvnDebug
+
+Each IT runs in a forked Maven process. The easiest way to attach a JVM debugger to that process is to set the [`mavenExecutable`](../run-mojo.html#mavenExecutable) parameter to `mvnDebug`. Maven ships this script next to `mvn`; it listens for a remote debugger on port 8000 and waits until one attaches.
+
+```shell
+mvn verify -Dinvoker.mavenExecutable=mvnDebug
+```
+
+Or in the plugin configuration:
+
+```xml
+<project>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <mavenExecutable>mvnDebug</mavenExecutable>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  ...
+</project>
+```
+
+You can also set it for a single project in `invoker.properties`:
+
+```properties
+invoker.mavenExecutable = mvnDebug
+```
+
+Then attach a remote debugger (for example Eclipse "Remote Java Application" via Run &gt; Open Debug Dialog...) to `localhost:8000`.
+
+To debug only one IT, combine this with [`invoker.test`](../run-mojo.html#invokerTest):
+
+```shell
+mvn verify -Dinvoker.mavenExecutable=mvnDebug -Dinvoker.test=my-it
+```
+
+# Using mavenOpts
+
+If you need a different listen address or port, leave the default Maven executable and pass a JDWP agent through [`mavenOpts`](../run-mojo.html#mavenOpts) (`MAVEN_OPTS` of the forked Maven):
+
+```shell
+mvn verify -Dinvoker.mavenOpts="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005"
+```
+
+# The debug parameter
+
+The [`debug`](../run-mojo.html#debug) parameter (`invoker.debug`) only enables Maven debug logging (`-X`) for the forked builds. It does not start a JVM debugger.

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -47,6 +47,7 @@ If you feel like the plugin is missing a feature or has a defect, you can fill a
 The following example configurations are available to illustrate selected use cases in more detail:
 
 - [Clone projects](./examples/clone-projects.html) to a temporary directory before running.
+- [Debug tests](./examples/debugging.html) with a remote JVM debugger (`mvnDebug`).
 - [Filter files](./examples/filtering.html) to introduce some updates before starting the build.
 - [Install](./examples/install-artifacts.html) projects artifacts to a local repository before running.
 - [Run a BeanShell or Groovy script](./examples/pre-post-build-script.html) to prepare or verify project.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -41,6 +41,7 @@ under the License.
     <menu name="Examples">
       <item name="Accessing Test Classes" href="examples/access-test-classes.html"/>
       <item name="Cloning Projects" href="examples/clone-projects.html"/>
+      <item name="Debugging Tests" href="examples/debugging.html"/>
       <item name="Filtering Files" href="examples/filtering.html"/>
       <item name="Fast Build Configuration" href="examples/fast-use.html"/>
       <item name="Installing Artifacts" href="examples/install-artifacts.html"/>


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Adds an examples page like surefire's debugging docs. `debug` / `invoker.debug` only turns on Maven `-X` logging. For a remote JVM debugger, set `mavenExecutable` to `mvnDebug` (listens on 8000) or pass a JDWP agent through `mavenOpts`.

Fixes #708
