### PR TITLE
Drop branch protection for the retired maven-invoker-plugin-3.7.x line

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,7 +26,6 @@ github:
     - maven
   protected_branches:
     master: { }
-    maven-invoker-plugin-3.7.x: { }
   pull_requests:
     del_branch_on_merge: true
   enabled_merge_buttons:


### PR DESCRIPTION
Prerequisite for retiring `maven-invoker-plugin-3.7.x`; see apache/maven-doxia#1079 for the containment evidence
and what the retirement costs. Nothing else in the file changes.

*This change was created with AI assistance.*
