### PR TITLE
Implement getOutputPath() and deprecate getOutputName()

### DIFF
--- a/src/main/java/org/apache/maven/plugins/invoker/InvokerReport.java
+++ b/src/main/java/org/apache/maven/plugins/invoker/InvokerReport.java
@@ -99,7 +99,20 @@ public class InvokerReport extends AbstractMavenReport {
         return getI18nString(locale, "description");
     }
 
+    /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
     public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getOutputPath() {
         return "invoker";
     }
 


### PR DESCRIPTION
Adopts the report output method that Maven Reporting API 4.0.0 introduced, following the pattern in the [report plugin guide](https://maven.apache.org/guides/plugin/guide-java-report-plugin-development.html) and already used by maven-javadoc-plugin and maven-pmd-plugin: `getOutputPath()` carries the value, and `getOutputName()` stays as a deprecated delegate because the API still declares it abstract.

No behaviour change — the rendered report paths are the same strings.

*This change was created with AI assistance.*
